### PR TITLE
Join stored channels on connection (closes #32)

### DIFF
--- a/internal/app/subgrok/event.go
+++ b/internal/app/subgrok/event.go
@@ -39,8 +39,15 @@ func (b *Bot) callback001(e *irc.Event) {
 		b.Connection.Privmsgf("nickserv", "identify %s %s", b.Config.IRC.NickservAccount, b.Config.IRC.NickservPassword)
 	}
 
-	// TODO: join stored channels as well as administrative ones
 	b.joinChannels(b.Config.IRC.AdminChannels)
+
+	channels, err := b.Database.GetChannels()
+
+	if err == nil {
+		b.joinChannels(channels)
+	} else {
+		b.Connection.Log.Printf("Error retrieving stored channels: " + err.Error())
+	}
 }
 
 // callback353 runs when a response to /NAMES is seen

--- a/internal/pkg/store/channel.go
+++ b/internal/pkg/store/channel.go
@@ -77,8 +77,13 @@ func (f *FileDB) GetChannels() ([]string, error) {
 
 	var channels []string
 
-	for channel := range(subscriptions) {
-		channels = append(channels, channel)
+	for channel, subreddits := range subscriptions {
+		for _, subscribed := range subreddits {
+			if subscribed {
+				channels = append(channels, channel)
+				break
+			}
+		}
 	}
 
 	return channels, nil

--- a/internal/pkg/store/channel.go
+++ b/internal/pkg/store/channel.go
@@ -67,3 +67,19 @@ func (f *FileDB) GetSubscriptions() (map[string]map[string]bool, error) {
 
 	return subscriptions, err
 }
+
+func (f *FileDB) GetChannels() ([]string, error) {
+	subscriptions, err := f.GetSubscriptions()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var channels []string
+
+	for channel := range(subscriptions) {
+		channels = append(channels, channel)
+	}
+
+	return channels, nil
+}


### PR DESCRIPTION
# Changelog

## Added

* The bot now joins channels which have at least one enabled subscription when it connects to the IRC network (#32).