### PR TITLE
Add configuration option to restrict number of subscriptions per channel (#34)

### DIFF
--- a/internal/app/subgrok/event.go
+++ b/internal/app/subgrok/event.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	commandSubscribe   = "subscribe"
-	commandUnsubscribe = "unsubscribe"
+	commandSubscribe     = "subscribe"
+	commandSubscriptions = "subscriptions"
+	commandUnsubscribe   = "unsubscribe"
 
 	prefixChannel      = "#"
 	prefixHalfOperator = "%"
@@ -104,12 +105,23 @@ func (b *Bot) callbackPrivmsg(e *irc.Event) {
 
 	b.Connection.Log.Println(e.Message())
 
+	arguments := &command.SubscribeToggleArguments{
+		Channel:          channel,
+		Config:           b.Config,
+		Database:         b.Database,
+		MessageArguments: messageToArguments(e.Message()),
+	}
+
 	// Keep it simple for now; we only have two commands (consider dispatch map
 	// if the scope grows)
 	if b.isCommand(e.Message(), commandSubscribe) {
-		response = command.ToggleSubscription(channel, messageToArguments(e.Message()), true, b.Database)
+		arguments.Subscribed = true
+		response = command.ToggleSubscription(arguments)
 	} else if b.isCommand(e.Message(), commandUnsubscribe) {
-		response = command.ToggleSubscription(channel, messageToArguments(e.Message()), false, b.Database)
+		arguments.Subscribed = false
+		response = command.ToggleSubscription(arguments)
+	} else if b.isCommand(e.Message(), commandSubscriptions) {
+		response = command.ListSubscriptions(arguments)
 	}
 
 	if response != "" {

--- a/internal/pkg/command/command.go
+++ b/internal/pkg/command/command.go
@@ -5,19 +5,30 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/snoonetIRC/subgrok/internal/pkg/config"
 	"github.com/snoonetIRC/subgrok/internal/pkg/store"
 )
 
 const (
+	errInternal                  = "An internal error occurred"
 	errNoArguments               = "A subreddit name is required (e.g. 'irc')"
 	errSubredditTooLong          = "Subreddit name is too long (maximum 20 characters)"
 	errSubredditValidationFailed = "Subreddit name failed validation"
+	errTooManySubscriptions      = "Channel has too many subscriptions (maximum %d)"
 
 	subredditPrefix = "/r/"
 )
 
-func ToggleSubscription(channel string, messageArguments []string, subscribed bool, s *store.FileDB) string {
-	subreddit := normaliseSubreddit(messageArguments)
+type SubscribeToggleArguments struct {
+	Channel          string
+	MessageArguments []string
+	Subscribed       bool
+	Database         *store.FileDB
+	Config           *config.Config
+}
+
+func ToggleSubscription(a *SubscribeToggleArguments) string {
+	subreddit := normaliseSubreddit(a.MessageArguments)
 
 	if subreddit == "" {
 		return errNoArguments
@@ -27,31 +38,54 @@ func ToggleSubscription(channel string, messageArguments []string, subscribed bo
 		return errSubredditTooLong
 	}
 
+	if a.Subscribed {
+		maxSubscriptionCount := a.Config.Application.ChannelMaximumSubscriptions
+		channelSubscriptionCount, err := a.Database.GetChannelSubscriptionCount(a.Channel)
+
+		if err != nil {
+			return errInternal
+		}
+
+		if channelSubscriptionCount >= maxSubscriptionCount {
+			return fmt.Sprintf(errTooManySubscriptions, maxSubscriptionCount)
+		}
+	}
+
 	matched, err := regexp.MatchString(`^[A-Za-z0-9-_]+$`, subreddit)
 
 	if err != nil || !matched {
 		return errSubredditValidationFailed
 	}
 
-	err = s.ToggleSubscription(channel, subreddit, subscribed)
+	err = a.Database.ToggleSubscription(a.Channel, subreddit, a.Subscribed)
 
 	if err != nil {
 		failureMessage := "Failed to subscribe %s to %s"
 
-		if !subscribed {
+		if !a.Subscribed {
 			failureMessage = "Failed to unsubscribe %s from %s"
 		}
 
-		return fmt.Sprintf(failureMessage, channel, subreddit)
+		return fmt.Sprintf(failureMessage, a.Channel, subreddit)
 	}
 
 	successMessage := "Subscribed %s to %s"
 
-	if !subscribed {
+	if !a.Subscribed {
 		successMessage = "Unsubscribed %s from %s"
 	}
 
-	return fmt.Sprintf(successMessage, channel, subreddit)
+	return fmt.Sprintf(successMessage, a.Channel, subreddit)
+}
+
+func ListSubscriptions(a *SubscribeToggleArguments) string {
+	subscriptions, err := a.Database.GetChannelSubscriptions(a.Channel)
+
+	if err != nil {
+		return errInternal
+	}
+
+	return fmt.Sprintf("%s subscribes to: %s", a.Channel, strings.Join(subscriptions, ", "))
 }
 
 // normaliseSubreddit converts a subreddit name to the internal standard, which

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -96,6 +96,7 @@ var exampleValidConfig = &Config{
 		PollWaitTime:     60,
 		PollWaitDuration: time.Duration(60 * time.Second),
 	},
+	Application: &applicationConfig{ChannelMaximumSubscriptions: defaultChannelMaximumSubscriptions},
 }
 
 type processorMockValidContent struct{ mock.Mock }
@@ -185,7 +186,7 @@ func TestLoad(t *testing.T) {
 			name:          "Missing database filepath",
 			want:          &Config{},
 			wantErr:       true,
-			wantErrMsg:    "A database filepath is required (config database.filepath)",
+			wantErrMsg:    "a database filepath is required (config database.filepath)",
 			processorMock: &processorMockInvalidDatabaseFilepath{},
 		},
 		{


### PR DESCRIPTION
# Changelog

## Added

* `application.channel_maximum_subscriptions` configuration option, which sets the maximum number of subreddits a channel may subscribe to.
* `!subscriptions` command, which lists the subreddits a channel is subscribed to.