### PR TITLE
Delay announcement of posts within a given window (closes #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,24 @@ the application's most recent releases.
 Linux x86_64 binaries are automatically attached to every build. This guide
 assumes you would like to host the bot on a 64 bit Linux server.
 
-### Configuration reference
+### reddit authentication
 
-Please be aware that the recommended value for `reddit.poll_wait_time` is
-"600". A smaller value may result in your IP address being blocked from
-Reddit's API.
+You will need to register an app on reddit in order to get credentials for
+their API. See the information [here](https://github.com/reddit-archive/reddit/wiki/OAuth2-Quick-Start-Example#first-steps).
+You will need:
+
+| Credential          | Config element in Subgrok's YAML | Description                            |
+| :------------------ | :------------------------------- | :------------------------------------- |
+| Username            | `reddit.username`                | Your reddit account's username         |
+| Password            | `reddit.password`                | Your reddit account's password         |
+| Client ID           | `reddit.id`                      | Your application's client ID           |
+| Secret access token | `reddit.secret`                  | Your application's secret access token |
+
+It is recommended that you create a separate reddit account with no two-factor
+authentication in order to use the bot (2FA seems to break the reddit API
+client).
+
+### Configuration reference
 
 ```yaml
 ---
@@ -83,7 +96,8 @@ irc:
 
 # "reddit" is configuration for our use of the reddit API
 reddit:
-  poll_wait_time: 600 # Time to wait (seconds) between reddit API calls
+  poll_wait_duration: 10m # Time to wait between reddit API calls
+  minimum_post_age: 2m # How old the post must be to be displayed
 
 # "database" is configuration for the database
 database:
@@ -117,7 +131,7 @@ commands:
 
 ### Building
 
-If you would like to build the application yourself, you will need Golang 1.17+.
+If you would like to build the application yourself, you will need Golang 1.18+.
 
 ```
 % go build -o subgrok ./cmd/subgrok/main.go

--- a/internal/app/subpoll/poller.go
+++ b/internal/app/subpoll/poller.go
@@ -22,12 +22,12 @@ type Poller struct {
 	Config        *config.Config
 	Subscriptions *subscription.Subscriptions
 	LastPoll      *time.Time
+	TooRecent     map[string]bool
 }
 
 // Load builds a new Poller
 func Load(config *config.Config, bot *subgrok.Bot) *Poller {
-	//client, err := reddit.NewClient(*config.Reddit.Credentials())
-	client, err := reddit.NewReadonlyClient()
+	client, err := reddit.NewClient(*config.Reddit.Credentials())
 
 	if err != nil {
 		panic(err)
@@ -40,6 +40,8 @@ func Load(config *config.Config, bot *subgrok.Bot) *Poller {
 
 		Subscriptions: &subscription.Subscriptions{},
 	}
+
+	poller.TooRecent = make(map[string]bool)
 
 	poller.Subscriptions.ReloadFromDatabase(bot.Database)
 
@@ -75,7 +77,12 @@ func (p *Poller) Poll() {
 				var errorStrings []string
 
 				for _, err := range errs {
-					errorStrings = append(errorStrings, err.Error())
+					// Strip console-spamming "badger badger badger" message from
+					// reddit's rate-limiting error page
+					e := err.Error()
+					e = strings.ReplaceAll(e, "badger ", "")
+
+					errorStrings = append(errorStrings, e)
 				}
 
 				p.Bot.Connection.Log.Printf("Received errors from reddit: %s", strings.Join(errorStrings, ", "))
@@ -92,17 +99,30 @@ func (p *Poller) checkSubscriptions() ([]*alert.Alert, []error) {
 		alerts       []*alert.Alert
 	)
 
-	posts, _, err := p.API.Subreddit.NewPosts(context.Background(), p.Subscriptions.ToSubredditString(), &reddit.ListOptions{
-		Limit: 5 * len(p.Subscriptions.Subreddits),
+	posts, client, err := p.API.Subreddit.NewPosts(context.Background(), p.Subscriptions.ToSubredditString(), &reddit.ListOptions{
+		Limit: 10 * len(p.Subscriptions.Subreddits),
 	})
 
 	if err != nil {
 		redditErrors = append(redditErrors, err)
+	} else {
+		p.Bot.Connection.Log.Printf("API requests: used %d, remaining %d (resets %s)",
+			client.Rate.Used, client.Rate.Remaining, client.Rate.Reset.String())
 	}
 
+	tooRecent := make(map[string]bool)
+
 	for _, post := range posts {
-		if p.LastPoll == nil || !post.Created.After(*p.LastPoll) {
-			continue // Skip posts which were created before the last poll time
+		// Skip posts which were created before the last poll time unless they
+		// were deemed to be too new to display
+		if p.LastPoll == nil || (!p.TooRecent[post.ID] && !post.Created.After(*p.LastPoll)) {
+			continue
+		}
+
+		if !p.postIsOldEnough(post) {
+			tooRecent[post.ID] = true
+
+			continue // Skip posts that aren't yet old enough
 		}
 
 		if err != nil {
@@ -116,6 +136,10 @@ func (p *Poller) checkSubscriptions() ([]*alert.Alert, []error) {
 		})
 	}
 
+	// Clean up post delay cache - some of the old items could be removed by
+	// moderators and end up staying in there forever
+	p.TooRecent = tooRecent
+
 	p.setLastPollTime()
 
 	return alerts, redditErrors
@@ -126,4 +150,21 @@ func (p *Poller) checkSubscriptions() ([]*alert.Alert, []error) {
 func (p *Poller) setLastPollTime() {
 	lastPoll := time.Now().UTC()
 	p.LastPoll = &lastPoll
+}
+
+func (p *Poller) postIsOldEnough(post *reddit.Post) bool {
+	var minimumPostAgeSeconds = p.Config.Reddit.MinimumPostAge
+
+	if minimumPostAgeSeconds == 0 {
+		return true
+	}
+
+	oldEnough := time.Since(post.Created.Time) > p.Config.Reddit.MinimumPostAge
+
+	if !oldEnough && p.Config.IRC.Debug {
+		p.Bot.Connection.Log.Printf("Post isn't old enough: %s (%s) (Minimum %.4f seconds)\n",
+			post.Title, post.Created.String(), p.Config.Reddit.MinimumPostAge.Seconds())
+	}
+
+	return oldEnough
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -50,13 +50,13 @@ type ircConfig struct {
 
 // redditConfig contains the bot's reddit authentication configuration.
 type redditConfig struct {
-	ID           string `yaml:"id"`
-	Secret       string `yaml:"secret"`
-	Username     string `yaml:"username"`
-	Password     string `yaml:"password"`
-	PollWaitTime int    `yaml:"poll_wait_time"`
+	ID       string `yaml:"id"`
+	Password string `yaml:"password"`
+	Secret   string `yaml:"secret"`
+	Username string `yaml:"username"`
 
-	PollWaitDuration time.Duration
+	PollWaitDuration time.Duration `yaml:"poll_wait_duration"`
+	MinimumPostAge   time.Duration `yaml:"minimum_post_age"`
 }
 
 type applicationConfig struct {
@@ -99,20 +99,19 @@ func Load() (*Config, error) {
 }
 
 func (c *Config) applyDefaults() {
-	if c.Reddit == nil {
-		c.Reddit = &redditConfig{}
+	if c.Application == nil {
+		c.Application = &applicationConfig{}
 	}
-
-	c.Reddit.applyDefaults()
 
 	if c.IRC == nil {
 		c.IRC = &ircConfig{}
 	}
 
-	if c.Application == nil {
-		c.Application = &applicationConfig{}
+	if c.Reddit == nil {
+		c.Reddit = &redditConfig{}
 	}
 
+	c.Reddit.applyDefaults()
 	c.Application.applyDefaults()
 
 	if c.IRC.CommandPrefix == "" {
@@ -125,11 +124,11 @@ func (ic *ircConfig) Hostname() string {
 }
 
 func (rc *redditConfig) applyDefaults() {
-	if rc.PollWaitTime < defaultRedditPollWaitTime {
-		rc.PollWaitTime = defaultRedditPollWaitTime
-	}
+	defaultPollWaitTime := time.Duration(defaultRedditPollWaitTime * time.Second)
 
-	rc.PollWaitDuration = time.Duration(rc.PollWaitTime) * time.Second
+	if rc.PollWaitDuration <= defaultPollWaitTime {
+		rc.PollWaitDuration = time.Duration(defaultPollWaitTime)
+	}
 }
 
 func (rc *redditConfig) Credentials() *reddit.Credentials {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -34,7 +34,7 @@ reddit:
   secret: secret
   username: username
   password: password
-  poll_wait_time: 60
+  poll_wait_duration: 60s
 `
 
 const exampleBadConfig = `
@@ -69,7 +69,7 @@ reddit:
   secret: secret
   username: username
   password: password
-  poll_wait_time: 59
+  poll_wait_duration: 59s
 `
 
 var exampleValidConfig = &Config{
@@ -93,7 +93,6 @@ var exampleValidConfig = &Config{
 		Secret:           "secret",
 		Username:         "username",
 		Password:         "password",
-		PollWaitTime:     60,
 		PollWaitDuration: time.Duration(60 * time.Second),
 	},
 	Application: &applicationConfig{ChannelMaximumSubscriptions: defaultChannelMaximumSubscriptions},
@@ -190,7 +189,7 @@ func TestLoad(t *testing.T) {
 			processorMock: &processorMockInvalidDatabaseFilepath{},
 		},
 		{
-			name:          "reddit PollWaitTime below minimum",
+			name:          "reddit PollWaitDuration below minimum",
 			want:          exampleValidConfig,
 			processorMock: &processorMockInvalidRedditWaitTime{},
 		},


### PR DESCRIPTION
# Changelog

## Added

* `reddit.minimum_post_age` config item. This is a duration (10s, 1m, 1h etc) which controls ignoring posts under a certain age. This gives Automod time to clean up spam posts.

## Changed

* The `reddit.poll_wait_time`  config item is now called `reddit.poll_wait_duration`, and accepts a duration (10s, 1m, 1h etc).
* The reddit API client now requires a real, registered application and its configuration. Instructions can be found in the README. This is to avoid the rate-limiting problems which come with using a generic client with a generic user-agent.